### PR TITLE
fix/and mention separator

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -37,6 +37,7 @@ cffi==1.16.0
 cfgv==3.4.0
     # via pre-commit
 discord-py @ git+https://github.com/Rapptz/discord.py.git@d853a3f0a7e19d290021434e85f9c4c14089a874
+    # via discord-py
     # via ductile-ui
 distlib==0.3.8
     # via virtualenv
@@ -91,8 +92,6 @@ pyyaml==6.0.1
 result==0.16.1
 ruff==0.4.1
 sentry-sdk==1.45.0
-setuptools==69.5.1
-    # via nodeenv
 sniffio==1.3.1
     # via anyio
     # via httpx
@@ -107,3 +106,5 @@ virtualenv==20.25.3
     # via pre-commit
 yarl==1.9.4
     # via aiohttp
+setuptools==69.5.1
+    # via nodeenv

--- a/requirements.lock
+++ b/requirements.lock
@@ -35,6 +35,7 @@ cffi==1.16.0
     # via pycares
     # via pynacl
 discord-py @ git+https://github.com/Rapptz/discord.py.git@d853a3f0a7e19d290021434e85f9c4c14089a874
+    # via discord-py
     # via ductile-ui
 ductile-ui==0.2.6
 face==20.1.1

--- a/src/app/core/role/cog.py
+++ b/src/app/core/role/cog.py
@@ -90,7 +90,7 @@ class Role(commands.Cog):
         for string in chunk_str_iter_with_max_length(
             target_mentions,
             max_length=2000,
-            separator="\n",
+            separator=" ",
             ignore_oversize_fragment=True,
         ):
             await channel.send(content=string)


### PR DESCRIPTION
`/role and-mention`の区切り文字を改行にすると大きすぎるので、短くする。

以下原文

> メンション時、一人ずつ改行しないで半角スペース区切りにしたほうが場所取らなくて好みなのですが、いかがでしょうか？
>
> @ someone1 @ someone2

- **fix: shorter mention separator**
- **build: update lock file**
