### PR TITLE
GitHub Actionsの改善

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,9 +1,6 @@
 name: check
 
 on:
-  push:
-    branches-ignore:
-      - master
   pull_request:
     types:
       - opened

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,11 +38,11 @@ jobs:
           pip install -r requirements-dev.lock
 
       - name: lint
-        if: ${{ always() && steps.install.outcome == 'success' }}
+        if: steps.install.outcome == 'success'
         run: |
           ruff check --output-format github .
 
-      - name: format
-        if: ${{ always() && steps.install.outcome == 'success' }}
+      - name: check format
+        if: steps.install.outcome == 'success'
         run: |
           ruff format --check .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: setup CPython
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           cache: "pip"
           cache-dependency-path: "requirements-dev.lock"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,10 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/conoha.yml
+++ b/.github/workflows/conoha.yml
@@ -37,12 +37,12 @@ jobs:
           pip install -r requirements-dev.lock
 
       - name: lint
-        if: ${{ always() && steps.install.outcome == 'success' }}
+        if: steps.install.outcome == 'success'
         run: |
           ruff check --output-format github .
 
-      - name: format
-        if: ${{ always() && steps.install.outcome == 'success' }}
+      - name: check format
+        if: steps.install.outcome == 'success'
         run: |
           ruff format --check .
 

--- a/.github/workflows/conoha.yml
+++ b/.github/workflows/conoha.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - "**.md"
-      - ".vscode/**"
   workflow_dispatch:
 
 concurrency:
@@ -18,7 +15,10 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -47,9 +47,9 @@ jobs:
           ruff format --check .
 
   deploy:
-    runs-on: ubuntu-latest
-
     needs: check
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/conoha.yml
+++ b/.github/workflows/conoha.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: setup CPython
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           cache: "pip"
           cache-dependency-path: "requirements-dev.lock"
@@ -56,20 +56,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4 # v3.4.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile
@@ -79,7 +79,7 @@ jobs:
           cache-to: type=gha, mode=max
 
       - name: SSH to ConoHa VPS
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799 # v1.0.0
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.SSH_USER }}

--- a/.github/workflows/conoha.yml
+++ b/.github/workflows/conoha.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           ruff format --check .
 
-  deploy:
+  build:
     needs: check
     runs-on: ubuntu-22.04
     timeout-minutes: 5
@@ -78,6 +78,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha, mode=max
 
+  deploy:
+    needs: build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
       - name: SSH to ConoHa VPS
         uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799 # v1.0.0
         with:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4 # v3.4.0
 
       - name: Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -4,10 +4,10 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - "**.md"
-      - ".vscode/**"
-  workflow_dispatch:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,7 +15,11 @@ concurrency:
 
 jobs:
   docker-build-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    timeout-minutes: 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/ @sushi-chaaaan

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Add your description here"
 authors = [{ name = "sushi-chaaaan", email = "mail@sushichan.live" }]
 dependencies = [
-    "discord-py[voice,speed] @ git+https://github.com/Rapptz/discord.py.git@978a96b25c47a818289ddb9ecc31d78d6a80b2bf",
+    "discord-py[voice,speed]>=2.4.0",
     "pydantic>=2.8.0",
     "aiohttp>=3.9.5",
     "ductile-ui>=0.3.0",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json.schemastore.org/renovate.json",
+    "extends": [
+        "config:best-practices"
+    ],
+    "timezone": "Asia/Tokyo",
+    "prHourlyLimit": 0,
+    "automerge": false,
+    "rangeStrategy": "bump",
+    "branchConcurrentLimit": 0,
+    "enabledManagers": [
+        "github-actions"
+    ]
+}

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -35,7 +35,7 @@ certifi==2024.7.4
 cffi==1.16.0
     # via pycares
     # via pynacl
-discord-py @ git+https://github.com/Rapptz/discord.py.git@978a96b25c47a818289ddb9ecc31d78d6a80b2bf
+discord-py==2.4.0
     # via ductile-ui
 ductile-ui==0.3.0
 face==20.1.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -35,7 +35,7 @@ certifi==2024.7.4
 cffi==1.16.0
     # via pycares
     # via pynacl
-discord-py @ git+https://github.com/Rapptz/discord.py.git@978a96b25c47a818289ddb9ecc31d78d6a80b2bf
+discord-py==2.4.0
     # via ductile-ui
 ductile-ui==0.3.0
 face==20.1.1


### PR DESCRIPTION
closes: #101 
- runnerのOSを指定
- 各actionのバージョン指定をハッシュベースに変更
- permission, timeout-minutesの設定
- `.github`ディレクトリにCODEOWNERSを指定
- `conoha.yml`において、buildとdeployのジョブを分割することで権限を最小に抑える
- `check.yml`において、on:pushイベントトリガーを削除
- renovateでActionsを自動更新