### PR TITLE
Wake on LAN機能の修正

### DIFF
--- a/src/app/wol/fn.py
+++ b/src/app/wol/fn.py
@@ -63,7 +63,12 @@ async def boot_computer(computer: ComputerType) -> ComputerBootResult:
             data={"mac_address": LEFT_PC_MAC_ADDRESS if computer == "left" else RIGHT_PC_MAC_ADDRESS},
         ) as response,
     ):
-        return ComputerBootResult(await response.text())
+        res = await response.text()
+        if ComputerBootResult.STARTED.value in res:
+            return ComputerBootResult.STARTED
+        if ComputerBootResult.CANCELED.value in res:
+            return ComputerBootResult.CANCELED
+        return ComputerBootResult.ERROR
 
 
 class MissingEnvironmentValueError(Exception):

--- a/src/app/wol/view.py
+++ b/src/app/wol/view.py
@@ -5,7 +5,7 @@ from ductile import State, View
 from ductile.ui import Button
 from ductile.view import ViewObject
 
-from .fn import ComputerBootResult, boot_computer
+from .fn import ComputerBootResult, boot_computer, get_computer_status
 
 if TYPE_CHECKING:
     from .fn import ComputerStatus
@@ -43,6 +43,12 @@ class WOLView(View):
             case ComputerBootResult.ERROR:
                 await interaction.followup.send("エラーが発生しました。", ephemeral=True)
 
+    async def handle_refresh(self, interaction: Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+        current_status = await get_computer_status()
+        self.status.set_state(current_status)
+        await interaction.followup.send("状態を更新しました。", ephemeral=True)
+
     async def handle_wol_exit(self, interaction: Interaction) -> None:
         await interaction.response.defer(ephemeral=True)
         self.disabled.set_state(True)
@@ -71,19 +77,25 @@ class WOLView(View):
                 Button(
                     "左PCを起動する",
                     custom_id="wol_left",
-                    style={"color": "blurple", "disabled": self.disabled() or bool(self.status()["left"])},
+                    style={"color": "blurple", "disabled": self.disabled() or bool(self.status()["left"]), "row": 0},
                     on_click=self.handle_wol_left,
                 ),
                 Button(
                     "右PCを起動する",
                     custom_id="wol_right",
-                    style={"color": "blurple", "disabled": self.disabled() or bool(self.status()["right"])},
+                    style={"color": "blurple", "disabled": self.disabled() or bool(self.status()["right"]), "row": 0},
                     on_click=self.handle_wol_right,
+                ),
+                Button(
+                    "表示を更新する",
+                    custom_id="wol_refresh",
+                    style={"color": "green", "disabled": self.disabled(), "row": 0, "emoji": "🔄"},
+                    on_click=self.handle_refresh,
                 ),
                 Button(
                     "操作を終了する",
                     custom_id="wol_exit",
-                    style={"color": "red", "disabled": self.disabled()},
+                    style={"color": "red", "disabled": self.disabled(), "row": 1},
                     on_click=self.handle_wol_exit,
                 ),
             ],


### PR DESCRIPTION
#140 について、Staging で検証して発覚した2点を修正する

- レスポンスからEnumを生成する際、レスポンス文字列の部分一致で判断するところを完全一致で判断していた
- UI から表示を更新できず不便