### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/ @sushi-chaaaan
+.github/ @sushichan044


### PR DESCRIPTION
This pull request includes a small change to the `CODEOWNERS` file. The change updates the GitHub username for ownership of the `.github/` directory.

* [`CODEOWNERS`](diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bL1-R1): Updated GitHub username from `@sushi-chaaaan` to `@sushichan044`.