### PR TITLE
fix: Notion と Discord の url が両方含まれているパターンに対処

### DIFF
--- a/src/app/core/extract/cog.py
+++ b/src/app/core/extract/cog.py
@@ -51,7 +51,6 @@ class Extract(commands.Cog):
                     )
                 except Exception:
                     self.bot.logger.exception("dispand error: discord")
-            return
 
         if (n := matches["notion"]) is not None:
             self.__logger.debug("notion url found: %s", n)


### PR DESCRIPTION
Title is All
