### PR TITLE
feat: `/admin` コマンドで入部時に必要な ID を確認する用メッセージが送れるように

### DIFF
--- a/src/app/admin/cog.py
+++ b/src/app/admin/cog.py
@@ -1,0 +1,52 @@
+from typing import TYPE_CHECKING
+
+import discord
+from discord import Interaction, app_commands
+from discord.ext import commands
+
+from .view import AdminUserInfoView, user_info_view_embed
+
+if TYPE_CHECKING:
+    # import some original class
+    from src.app.bot import Bot
+
+
+class Admin(commands.Cog):
+    admin_group = app_commands.Group(name="admin", description="管理者向けのコマンド", guild_only=True)
+
+    def __init__(self, bot: "Bot") -> None:
+        self.bot = bot
+
+    @admin_group.command(
+        name="send-confirm-id-before-join-form",
+        description="入部申請フォーム記入時に必要な ID を引くためのメッセージを送信します",
+    )
+    @app_commands.rename(
+        target="送信先チャンネル",
+    )
+    @app_commands.describe(
+        target="メッセージを送信するチャンネル",
+    )
+    async def send_confirm_id_before_join_form(self, interaction: "Interaction", target: discord.TextChannel) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        if not interaction.permissions.administrator:
+            await interaction.followup.send(
+                content="このコマンドは管理者のみが実行できます。",
+                ephemeral=True,
+            )
+            return
+
+        sent = await target.send(
+            embed=user_info_view_embed(),
+            view=AdminUserInfoView(),
+        )
+
+        await interaction.followup.send(
+            content=(f"{target.mention} にメッセージを送信しました。\n[送信されたメッセージを見る]({sent.jump_url})"),
+            ephemeral=True,
+        )
+
+
+async def setup(bot: "Bot") -> None:
+    await bot.add_cog(Admin(bot))

--- a/src/app/admin/view.py
+++ b/src/app/admin/view.py
@@ -1,0 +1,53 @@
+import discord
+
+from src.app.user.view import UserIdCopyView
+
+
+def user_info_view_embed() -> discord.Embed:
+    return discord.Embed(
+        title="入部申請時に必要なユーザー固有 ID について",
+        description=(
+            "ユーザー名を変更しても誰か分かるようにするために、入部時にユーザーごとの固有 ID を取得しています。\n"
+            "このメッセージについているボタンから自分のものを確認できるので、申請フォームに記入をお願いします。"
+        ),
+    )
+
+
+def user_id_embed(user: discord.Member | discord.User) -> discord.Embed:
+    embed = discord.Embed()
+    embed.add_field(name="ユーザー名", value=user.display_name)
+    embed.add_field(
+        name="固有 ID",
+        value=user.id,
+    )
+    return embed
+
+
+class AdminUserInfoView(discord.ui.View):
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+
+    @discord.ui.button(
+        label="入部申請に必要な自分のユーザー情報を見る",
+        style=discord.ButtonStyle.primary,
+        custom_id="admin_user_info_view_get_user_information",
+    )
+    async def get_user_information(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        user = interaction.user
+
+        if not user:
+            await interaction.followup.send(
+                content="ユーザー情報が取得できませんでした。",
+                ephemeral=True,
+            )
+            return
+
+        embed = user_id_embed(user)
+        await interaction.followup.send(
+            embed=embed,
+            view=UserIdCopyView(bound_user=interaction.user),
+            allowed_mentions=discord.AllowedMentions.none(),  # 不要なメンションを避ける
+            ephemeral=True,
+        )

--- a/src/app/bot.py
+++ b/src/app/bot.py
@@ -9,6 +9,7 @@ import sentry_sdk
 from discord.ext import commands
 from sentry_sdk import Hub
 
+from src.app.admin.view import AdminUserInfoView
 from src.app.core.extract.view import DispandView
 from src.app.utils.view import DeleteView
 from src.config.intent import get_full_intents
@@ -96,6 +97,7 @@ class Bot(commands.Bot):
         # This parameter is not used after once sended
         # So, this is dummy value
         views: list[discord.ui.View] = [
+            AdminUserInfoView(),
             DispandView(message_url="MISSING", button_label="MISSING"),
             DeleteView(),
         ]

--- a/src/app/user/cog.py
+++ b/src/app/user/cog.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from discord import AllowedMentions, Interaction, Member, app_commands
 from discord.ext import commands
 
-from .view import UserEmbedView, user_embed
+from .view import UserIdCopyView, user_embed
 
 if TYPE_CHECKING:
     # import some original class
@@ -24,7 +24,7 @@ class User(commands.Cog):
         embed = user_embed(interaction.user)
         await interaction.followup.send(
             embed=embed,
-            view=UserEmbedView(bound_user=interaction.user),
+            view=UserIdCopyView(bound_user=interaction.user),
             allowed_mentions=AllowedMentions.none(),  # 不要なメンションを避ける
             ephemeral=True,
         )
@@ -38,7 +38,7 @@ class User(commands.Cog):
         embed = user_embed(user)
         await interaction.followup.send(
             embed=embed,
-            view=UserEmbedView(bound_user=user),
+            view=UserIdCopyView(bound_user=user),
             allowed_mentions=AllowedMentions.none(),  # 不要なメンションを避ける
             ephemeral=True,
         )

--- a/src/app/user/view.py
+++ b/src/app/user/view.py
@@ -23,7 +23,7 @@ def user_embed(
     return embed
 
 
-class UserEmbedView(discord.ui.View):
+class UserIdCopyView(discord.ui.View):
     def __init__(self, *, bound_user: discord.User | discord.Member) -> None:
         super().__init__(timeout=None)
         self.user = bound_user


### PR DESCRIPTION
幹部承認済み
`/admin send-confirm-id-before-join-form`
![image](https://github.com/user-attachments/assets/714c7971-aed1-4b03-b83a-0ec3135e361b)
