### PR TITLE
fix: update Notion URL regex pattern for app.notion.com

### DIFF
--- a/src/packages/url_extractor/plugins.py
+++ b/src/packages/url_extractor/plugins.py
@@ -20,5 +20,5 @@ class NotionPlugin(IUrlExtractorPlugin):
 
     def url_pattern(self) -> re.Pattern[str] | str:
         return re.compile(
-            rf"(?!<)https://www.notion.so/{self.__workspace}/" r"(?P<page_name>.+-)?(?P<page_uuid>[^\?]+)\??.*(?!>)"
+            rf"(?!<)https://((www\.)?notion\.so|app\.notion\.com/p)/{self.__workspace}/" r"(?P<page_name>.+-)?(?P<page_uuid>[^\?]+)\??.*(?!>)"
         )

--- a/src/packages/url_extractor/plugins.py
+++ b/src/packages/url_extractor/plugins.py
@@ -20,5 +20,6 @@ class NotionPlugin(IUrlExtractorPlugin):
 
     def url_pattern(self) -> re.Pattern[str] | str:
         return re.compile(
-            rf"(?!<)https://((www\.)?notion\.so|app\.notion\.com/p)/{self.__workspace}/" r"(?P<page_name>.+-)?(?P<page_uuid>[^\?]+)\??.*(?!>)"
+            rf"(?!<)https://((www\.)?notion\.so|app\.notion\.com/p)/{self.__workspace}/"
+            r"(?P<page_name>.+-)?(?P<page_uuid>[^\?]+)\??.*(?!>)"
         )


### PR DESCRIPTION
##経緯
https://discord.com/channels/1489288526829719705/1497612366106464298/1511701300583075853

## やったこと
Notion のページ URL の判定を `www.notion.so` 以外にも、`app.notion.com/p/` や `notion.so` に対応させました

## 動作確認
テスト環境で動作を確認しました
<img width="985" height="834" alt="image" src="https://github.com/user-attachments/assets/d8ceb99b-1af8-4433-8cac-6aa186c99361" />
